### PR TITLE
chore(dependabot): refine grouping to produce reviewable single-major PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,38 +1,57 @@
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-    groups:
-      actions:
-        patterns:
-          - '*'
-
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    versioning-strategy: increase
     groups:
-      types:
+      lint-format:
         patterns:
-          - '@types/*'
-      tooling:
+          - "@biomejs/*"
+      typecheck:
         patterns:
-          - 'turbo'
-          - '@biomejs/*'
-          - 'vitest'
-          - '@changesets/*'
-          - 'typescript'
-      runtime:
+          - "typescript"
+          - "@types/*"
+        exclude-patterns:
+          - "@types/node"
+      test:
         patterns:
-          - '@octokit/*'
-          - '@actions/*'
-          - 'zod'
-          - 'commander'
-          - 'eta'
-          - 'satori'
-          - '@resvg/*'
-          - '@react-pdf/*'
-          - 'pino'
+          - "vitest"
+          - "@vitest/*"
+          - "msw"
+      octokit:
+        patterns:
+          - "@octokit/*"
+      actions-toolkit:
+        patterns:
+          - "@actions/*"
+      docs:
+        patterns:
+          - "astro"
+          - "@astrojs/*"
+          - "starlight*"
+          - "sharp"
+      react-pdf-stack:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@react-pdf/*"
+          - "satori"
+          - "@resvg/*"
+    ignore:
+      - dependency-name: "@types/node"
+        versions:
+          - ">=21"
+      - dependency-name: "@vercel/ncc"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      gh-actions-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,20 @@ pnpm changeset
 
 The Action entrypoint is bundled with `@vercel/ncc` to `dist/index.js` at the repo root. CI runs `pnpm verify-dist` and fails if `dist/` is out of date relative to the source.
 
+## Updating `@vercel/ncc`
+
+`@vercel/ncc` is intentionally excluded from Dependabot. Dependabot cannot
+rebuild `dist/index.js` after bumping ncc, so its PRs would always trip the
+bundle-presence gate. To update ncc:
+
+1. `pnpm --filter @devportfolio/action add -D @vercel/ncc@latest`
+2. `pnpm --filter @devportfolio/action build`
+3. Commit both `package.json` / `pnpm-lock.yaml` and the regenerated `dist/`.
+4. Open a PR titled `chore(deps): bump @vercel/ncc to <version>`.
+
+The release workflow re-bundles on Linux before tagging, so the bundle that
+ships to the Marketplace is always deterministic regardless of the dev OS.
+
 ## Filing issues
 
 Please include:


### PR DESCRIPTION
## Why

The current grouping was too wide: it coalesced majors into 5- and 14-update mega-PRs that
can't be reviewed safely. Last sweep produced PRs that had to be closed wholesale (#3, #4)
because a single review couldn't cover that much surface area.

This refines the groups so each PR maps to one coherent concern.

## What changes

| Group | Members | Rationale |
|---|---|---|
| `lint-format` | `@biomejs/*` | Biome configs are coupled across packages |
| `typecheck` | `typescript`, `@types/*` (excl. `@types/node`) | TS + types move together |
| `test` | `vitest`, `@vitest/*`, `msw` | Vitest plugins are version-locked to vitest core |
| `octokit` | `@octokit/*` | Octokit plugins share peer ranges |
| `actions-toolkit` | `@actions/*` | GitHub-published, versioned together |
| `docs` | `astro`, `@astrojs/*`, `starlight*`, `sharp` | Pairs that broke when split (#6 / #9) |
| `react-pdf-stack` | `react`, `react-dom`, `@react-pdf/*`, `satori`, `@resvg/*` | Coupled by React peer (#10) |

## What stays separate

- **Majors outside groups** open as individual PRs — explicit review, no coalescing.
- **`@vercel/ncc` ignored entirely** — Dependabot can't rebuild `dist/`, so its PRs always
  fail the verify gate. Bump manually with a `dist/` rebuild; documented in `CONTRIBUTING.md`.
- **`@types/node` pinned to `<21`** — Node 20 LTS runtime, no exceptions until we move LTS.
- **GitHub Actions majors stay individual** — workflow regressions are silent until they bite,
  so each major gets a dedicated review.

## Verification

- [ ] CI green
- [ ] Next Dependabot sweep produces PRs that each map to one group above
- [ ] No PR contains more than one major version bump