### PR TITLE
chore: polish sweep (#33)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: [AbdullahBakir97]

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Something isn't working as documented
+title: "bug: "
+labels: [bug]
+---
+
+## What happened?
+
+<!-- Steps to reproduce, expected vs. actual behavior. -->
+
+## Environment
+
+- PortfolioCraft version (`v1.x.y` or commit SHA):
+- How invoked (Action / CLI):
+- Node version (must be 20.18.0+):
+- OS:
+
+## Workflow / command
+
+<!-- Paste the workflow excerpt or CLI command that triggered the bug. -->
+
+```yaml
+# .github/workflows/...
+```
+
+## Output
+
+<!--
+Run with --dry-run --explain and paste the output:
+  pnpm --filter portfoliocraft start generate --user <login> --dry-run --explain
+-->
+
+```
+```

--- a/.github/ISSUE_TEMPLATE/config-help.md
+++ b/.github/ISSUE_TEMPLATE/config-help.md
@@ -1,0 +1,28 @@
+---
+name: Config help
+about: Question about configuring the Action or CLI
+title: "config: "
+labels: [question]
+---
+
+## What are you trying to do?
+
+<!-- Goal in plain English. -->
+
+## What you tried
+
+<!-- Paste your `.portfoliocraft.yml` or workflow excerpt. -->
+
+```yaml
+```
+
+## What you got
+
+<!-- The output, error, or unexpected result. -->
+
+```
+```
+
+## What the docs say
+
+<!-- Link to the section of the README or docs site you were following, if any. -->

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea or improvement
+title: "feat: "
+labels: [enhancement]
+---
+
+## What problem does this solve?
+
+<!-- The user-visible pain point. Skip generic "wouldn't it be cool if…" framings. -->
+
+## Proposed solution
+
+<!-- What you'd like to see. Concrete inputs, outputs, or surface changes. -->
+
+## Alternatives considered
+
+<!-- Other approaches you ruled out and why. -->
+
+## Additional context
+
+<!-- Links, screenshots, related issues. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,26 @@ bundle-presence gate. To update ncc:
 The release workflow re-bundles on Linux before tagging, so the bundle that
 ships to the Marketplace is always deterministic regardless of the dev OS.
 
+## Known upstream issues
+
+### Astro on Windows (zod parse error)
+
+`apps/docs` (Astro 5.1.1) fails on Windows with a zod schema parse error
+inside Astro's internal config loader. To keep CI green on contributor
+machines, the `build` and `typecheck` scripts in `apps/docs/package.json`
+are no-ops; the real docs build runs in a dedicated Linux-only workflow
+(`pnpm --filter @portfoliocraft/docs build:site`).
+
+Once Astro 5.1.2+ ships with the upstream fix, restore the real scripts:
+
+```jsonc
+// apps/docs/package.json
+"build": "astro build",
+"typecheck": "astro check"
+```
+
+Tracking: <!-- TODO: link upstream Astro issue once filed -->
+
 ## Filing issues
 
 Please include:


### PR DESCRIPTION
## Summary

Knocks down the merge-safe items from #33:

- `.github/FUNDING.yml` — surface GitHub Sponsors
- `.github/ISSUE_TEMPLATE/{bug,feature,config-help}.md` — standardize intake
- `CONTRIBUTING.md` — document the Astro 5.1.1 Windows zod bug and the `apps/docs` typecheck/build no-op workaround, with a TODO to link the upstream issue once filed

## Out of scope (still open on #33)

Profile pin, profile-repo dogfood, marketplace banner, docs site deploy, social post — these need UI clicks, design assets, or work in another repo.

Closes #33 (partial).