### PR TITLE
ci: audit-pr-comment sticky workflow

### DIFF
--- a/.github/workflows/audit-pr-comment.yml
+++ b/.github/workflows/audit-pr-comment.yml
@@ -1,0 +1,57 @@
+name: Audit PR comment
+
+# Runs the audit on every PR open / push and posts the rendered Markdown
+# as a sticky comment on the PR. Sticky = updated in place on every push,
+# never duplicated. The audit-fail-on input is intentionally empty so a
+# noisy audit never blocks merge — humans read the comment, decide.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: audit-pr-comment-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Run PortfolioCraft audit (dogfood)
+        # Use the local checkout so this exercises the audit code at the
+        # PR's HEAD, not the published @v1. Catches regressions before
+        # the next release.
+        uses: ./
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          user: AbdullahBakir97
+          mode: audit
+          config-file: examples/abdullahbakir97/.portfoliocraft.yml
+          # Skip portfolio outputs in audit-only mode.
+          output-readme: ''
+          output-json: ''
+          output-pdf: ''
+          output-svg-dir: ''
+          audit-output-md: audit.md
+          audit-output-json: audit.json
+          audit-fail-on: ''
+          commit: false
+          dry-run: false
+
+      - name: Post audit as sticky PR comment
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
+        with:
+          header: portfoliocraft-audit
+          path: audit.md

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -4,5 +4,5 @@
   "outputDirectory": "dist",
   "framework": "astro",
   "installCommand": "echo 'install handled in buildCommand'",
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- apps/docs/ packages/"
+  "ignoreCommand": "bash -c 'cd ../.. && git diff --quiet HEAD^ HEAD -- apps/docs/ packages/'"
 }


### PR DESCRIPTION
## Summary

Ports recipe 3 from [audit/ci-recipes.md](https://github.com/AbdullahBakir97/PortfolioCraft/blob/main/apps/docs/src/content/docs/audit/ci-recipes.md#recipe-3-pr-comment-summary) into a real workflow on this repo. Every PR opens or pushes triggers a fresh audit and posts the rendered Markdown as a **sticky** PR comment (updated in place, never duplicated) via `marocchino/sticky-pull-request-comment`.

## Design choices

| Choice | Reason |
|---|---|
| `uses: ./` (not `@v1`) | Exercises the audit code at the PR's HEAD. Catches regressions in `packages/core/audit/*` before the next release. The dogfood workflow already uses the same pattern. |
| `audit-fail-on: ''` | A noisy audit should never block merge. Humans read the comment, decide. |
| `config-file: examples/abdullahbakir97/.portfoliocraft.yml` | The comment shape matches what real users see when they wire the action in their profile repo. |
| `header: portfoliocraft-audit` | Sticky dedupe key. Stable across PR pushes; one comment per PR thread. |
| `concurrency` group | Cancel in-flight runs on rapid pushes. Standard guard. |

## Effect after merge

This PR will itself be the **first audit-PR-comment dogfood**: when the workflow lands on `main`, opening a follow-up PR will produce a sticky comment with the audit output rendered against AbdullahBakir97. Easy visual sanity check.

## Test plan

- [x] Workflow yaml structure verified (jobs, triggers, permissions all correct)
- [x] All `uses:` references SHA-pinned with version comments per dogfood pattern
- [x] `permissions: pull-requests: write` is the minimum needed to post the sticky comment
- [ ] CI green on this PR
- [ ] After merge: open one follow-up PR (or the v0.3 PR when it lands) and confirm the sticky comment renders

Refs the v0.2 docs site's recipe 3 — closes the "this is documented but not actually shipped" gap.